### PR TITLE
GDataXML-HTML throws exception when parsing empty string

### DIFF
--- a/GDataXML-HTML/lib/GDataXMLNode.m
+++ b/GDataXML-HTML/lib/GDataXMLNode.m
@@ -1846,7 +1846,7 @@ static xmlChar *SplitQNameReverse(const xmlChar *qname, xmlChar **prefix) {
 }
 
 - (NSArray *)nodesForXPath:(NSString *)xpath error:(NSError **)error {
-    return [self nodesForXPath:xpath namespaces:nil error:error];
+    return [self nodesForXPath:xpath namespaces:[NSDictionary dictionaryWithObject:@"" forKey:@"_def_ns"] error:error];
 }
 
 - (NSArray *)nodesForXPath:(NSString *)xpath


### PR DESCRIPTION
Hi there,
I noticed there's an exception thrown with GData when parsing empty/blank strings.

This pull request addresses this issue.

I would expect that parsing empty strings would not throw an exception but would produce a nil/empty document.

If you don't think this should be the expected behaviour, please disregard my pull request.
