### PR TITLE
Fix unsafe cast of an xmlDocPtr into a xmlNodePtr.

### DIFF
--- a/GDataXML-HTML/lib/GDataXMLNode.m
+++ b/GDataXML-HTML/lib/GDataXMLNode.m
@@ -1914,11 +1914,14 @@ const char *IANAEncodingCStringFromNSStringEncoding(NSStringEncoding encoding)
                 namespaces:(NSDictionary *)namespaces
                      error:(NSError **)error {
     if (xmlDoc_ != NULL) {
-        GDataXMLNode *docNode = [GDataXMLElement nodeBorrowingXMLNode:(xmlNodePtr)xmlDoc_];
-        NSArray *array = [docNode nodesForXPath:xpath
-                                     namespaces:namespaces
-                                          error:error];
-        return array;
+        xmlNodePtr rootElement = xmlDocGetRootElement(xmlDoc_);
+        if (rootElement != NULL) {
+            GDataXMLNode *rootNode = [GDataXMLElement nodeBorrowingXMLNode:rootElement];
+            NSArray *array = [rootNode nodesForXPath:xpath
+                                         namespaces:namespaces
+                                              error:error];
+            return array;
+        }
     }
     return nil;
 }


### PR DESCRIPTION
On 64-bit systems this has proven in my project to consistently lead to bad access memory crashes when an attempt is made to dereference a struct member which xmlDocPtr and xmlNodePtr don't hold in common. Specifically the 'namespace' member is attempted to be accessed inside [GDataXMLNode nodesForXPath:namespaces:error:] which a xmlDocPtr doesn't possess.
