### PR TITLE
add support for swift pod

### DIFF
--- a/Example/GDataXML-HTML.xcodeproj/project.pbxproj
+++ b/Example/GDataXML-HTML.xcodeproj/project.pbxproj
@@ -173,11 +173,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 962843C01BC0EC4E00784C86 /* Build configuration list for PBXNativeTarget "GDataXML-HTMLTests" */;
 			buildPhases = (
-				010930FBCD1CA697C97D98F7 /* Check Pods Manifest.lock */,
+				010930FBCD1CA697C97D98F7 /* [CP] Check Pods Manifest.lock */,
 				962843B31BC0EC4E00784C86 /* Sources */,
 				962843B41BC0EC4E00784C86 /* Frameworks */,
 				962843B51BC0EC4E00784C86 /* Resources */,
-				D8914B683F4AE66E3FFC029B /* Copy Pods Resources */,
+				D8914B683F4AE66E3FFC029B /* [CP] Copy Pods Resources */,
+				8025A4008C8F36864C1B0CF0 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -193,11 +194,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F43A13E413CF10F300FD689C /* Build configuration list for PBXNativeTarget "GDataXML-HTML" */;
 			buildPhases = (
-				89DE9BAF38CB288E8535AD4B /* Check Pods Manifest.lock */,
+				89DE9BAF38CB288E8535AD4B /* [CP] Check Pods Manifest.lock */,
 				F43A13BF13CF10F300FD689C /* Sources */,
 				F43A13C013CF10F300FD689C /* Frameworks */,
 				F43A13C113CF10F300FD689C /* Resources */,
-				022D0EC28BD0E62788449E39 /* Copy Pods Resources */,
+				022D0EC28BD0E62788449E39 /* [CP] Copy Pods Resources */,
+				CEF64A9D1F68B047F244CD7B /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -268,29 +270,29 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		010930FBCD1CA697C97D98F7 /* Check Pods Manifest.lock */ = {
+		010930FBCD1CA697C97D98F7 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		022D0EC28BD0E62788449E39 /* Copy Pods Resources */ = {
+		022D0EC28BD0E62788449E39 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -298,29 +300,59 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GDataXML-HTML/Pods-GDataXML-HTML-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		89DE9BAF38CB288E8535AD4B /* Check Pods Manifest.lock */ = {
+		8025A4008C8F36864C1B0CF0 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GDataXML-HTMLTests/Pods-GDataXML-HTMLTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D8914B683F4AE66E3FFC029B /* Copy Pods Resources */ = {
+		89DE9BAF38CB288E8535AD4B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		CEF64A9D1F68B047F244CD7B /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GDataXML-HTML/Pods-GDataXML-HTML-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D8914B683F4AE66E3FFC029B /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GDataXML-HTML.podspec
+++ b/GDataXML-HTML.podspec
@@ -16,16 +16,7 @@ Pod::Spec.new do |s|
   s.source_files		= "Pod/Classes"
   s.library			= "xml2"
   s.requires_arc		= true
-  s.xcconfig			= { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2 $(PODS_ROOT)/GDataXML-HTML/libxml" }
-  s.module_map			= 'libxml.modulemap'
-  s.prepare_command		= <<-CMD
-    cat > "libxml.modulemap" << MAP
-module libxml [system] {
-    header "$(SDKROOT)/usr/include/libxml2/libxml/tree.h"
-    link "libxml"
-    export *
-}
-MAP
-  CMD
+  s.xcconfig			= { "HEADER_SEARCH_PATHS" => "$(inherited) $(SDKROOT)/usr/include/libxml2" }
+
 
 end

--- a/Pod/Classes/GDataXMLNode.h
+++ b/Pod/Classes/GDataXMLNode.h
@@ -30,21 +30,6 @@
 
 #import <Foundation/Foundation.h>
 
-// libxml includes require that the target Header Search Paths contain
-//
-//   /usr/include/libxml2
-//
-// and Other Linker Flags contain
-//
-//   -lxml2
-
-#import <libxml/tree.h>
-#import <libxml/parser.h>
-#import <libxml/xmlstring.h>
-#import <libxml/HTMLparser.h>
-#import <libxml/xpath.h>
-#import <libxml/xpathInternals.h>
-
 
 #if (MAC_OS_X_VERSION_MAX_ALLOWED <= MAC_OS_X_VERSION_10_4) || defined(GDATA_TARGET_NAMESPACE)
 // we need NSInteger for the 10.4 SDK, or we're using target namespace macros
@@ -98,28 +83,7 @@ enum {
 
 typedef NSUInteger GDataXMLNodeKind;
 
-@interface GDataXMLNode : NSObject <NSCopying> {
-@protected
-    // NSXMLNodes can have a namespace URI or prefix even if not part
-    // of a tree; xmlNodes cannot.  When we create nodes apart from
-    // a tree, we'll store the dangling prefix or URI in the xmlNode's name,
-    // like
-    //   "prefix:name"
-    // or
-    //   "{http://uri}:name"
-    //
-    // We will fix up the node's namespace and name (and those of any children)
-    // later when adding the node to a tree with addChild: or addAttribute:.
-    // See fixUpNamespacesForNode:.
-    
-    xmlNodePtr xmlNode_; // may also be an xmlAttrPtr or xmlNsPtr
-    BOOL shouldFreeXMLNode_; // if yes, xmlNode_ will be free'd in dealloc
-    
-    // cached values
-    NSString *cachedName_;
-    NSArray *cachedChildren_;
-    NSArray *cachedAttributes_;
-}
+@interface GDataXMLNode : NSObject <NSCopying>
 
 + (GDataXMLElement *)elementWithName:(NSString *)name;
 + (GDataXMLElement *)elementWithName:(NSString *)name stringValue:(NSString *)value;
@@ -167,7 +131,7 @@ typedef NSUInteger GDataXMLNodeKind;
 
 // access to the underlying libxml node; be sure to release the cached values
 // if you change the underlying tree at all
-- (xmlNodePtr)XMLNode;
+//- (xmlNodePtr)XMLNode;
 - (void)releaseCachedValues;
 
 @end
@@ -198,11 +162,7 @@ typedef NSUInteger GDataXMLNodeKind;
 
 @end
 
-@interface GDataXMLDocument : NSObject {
-@protected
-    xmlDoc* xmlDoc_; // strong; always free'd in dealloc
-	NSStringEncoding _encoding;
-}
+@interface GDataXMLDocument : NSObject
 
 - (id)initWithXMLString:(NSString *)str encoding:(NSStringEncoding)encoding error:(NSError **)error;
 - (id)initWithData:(NSData *)data encoding:(NSStringEncoding)encoding error:(NSError **)error;


### PR DESCRIPTION
#import <libxml/tree.h>
#import <libxml/parser.h>
#import <libxml/xmlstring.h>
#import <libxml/HTMLparser.h>
#import <libxml/xpath.h>
#import <libxml/xpathInternals.h>

Headers import above in .h will fail the pod for swift project, just hide those libxml things to .m will satisfy swift pod.

Further more,  the module map is useless